### PR TITLE
Document v1.1.9 publication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,17 +2,16 @@
 
 ## Project Status
 
-Current milestone: version 1.1.9 release candidate. Version 1.1.8 is published
-to npm and GitHub with OIDC provenance; the review fixes merged through PR #7
-are staged for the 1.1.9 patch release.
+Current milestone: version 1.1.9 is published to npm and GitHub with OIDC
+provenance. The npm `latest` tag and GitHub release both point to 1.1.9.
 
 Known blockers: macOS/iOS WKWebView has not been run; the independent WebKit
 engine smoke is not native Apple platform certification.
 
-Next highest-leverage step: publish version 1.1.9 through the configured
-Trusted Publisher for `Bandonker/desktop-audio-proxy` and `publish.yml`; do not
-add an `NPM_TOKEN` write secret. Run the native Apple WKWebView smoke when
-macOS hardware is available.
+Next highest-leverage step: run the native Apple WKWebView smoke when macOS
+hardware is available. Continue publishing through the configured Trusted
+Publisher for `Bandonker/desktop-audio-proxy` and `publish.yml`; do not add an
+`NPM_TOKEN` write secret.
 
 ## How To Run
 

--- a/README.md
+++ b/README.md
@@ -144,12 +144,10 @@ yarn add desktop-audio-proxy
 pnpm add desktop-audio-proxy
 ```
 
-> **Release status:** this source tree declares version `1.1.9`, which remains
-> the workspace release candidate until the `v1.1.9` tag workflow succeeds.
-> Before that workflow completes, npm `latest` is `1.1.8`, so a normal install
-> resolves `1.1.8`. Check availability with
-> `npm view desktop-audio-proxy version`; after it reports `1.1.9`, install
-> that exact release with `npm install desktop-audio-proxy@1.1.9`.
+> **Release status:** version `1.1.9` is published as npm `latest`, so
+> `npm install desktop-audio-proxy` resolves `1.1.9`. Check the registry with
+> `npm view desktop-audio-proxy version`, or install the exact release with
+> `npm install desktop-audio-proxy@1.1.9`.
 > Version `1.1.9` contains `createMediaElementController`, `allowedHosts`, the
 > other documented `1.1.8` additions, and the `1.1.9` review fixes.
 

--- a/scripts/verify-docs.mjs
+++ b/scripts/verify-docs.mjs
@@ -43,11 +43,11 @@ assert(
   'README is missing the proxy host allowlist guidance'
 );
 assert(
-  readme.includes('source tree declares version `1.1.9`') &&
-    readme.includes('npm `latest` is `1.1.8`') &&
+  readme.includes('version `1.1.9` is published as npm `latest`') &&
+    readme.includes('`npm install desktop-audio-proxy` resolves `1.1.9`') &&
     readme.includes('`npm view desktop-audio-proxy version`') &&
     readme.includes('`npm install desktop-audio-proxy@1.1.9`'),
-  'README must distinguish the 1.1.9 candidate from npm latest'
+  'README must state the verified 1.1.9 npm latest status'
 );
 assert(
   /does\s+not ship the native metadata extractor/.test(readme),


### PR DESCRIPTION
## Summary

- record that npm latest and the GitHub release now point to 1.1.9
- keep the exact registry verification and install commands in the README
- update the repository handoff state after the successful OIDC release

## Verification

- npm view desktop-audio-proxy@1.1.9 version dist-tags dist.attestations --json
- npm run verify:docs